### PR TITLE
Adding support for Javascript files

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -68,18 +68,39 @@ internals.loadExtras = function (args) {
     }
 };
 
+internals.jsParser = function (manifestPath) {
+    try {
+        return require(manifestPath);
+    }
+    catch (err) {
+        console.log('Failed loading configuration file: ' + args.c + ' (' + err.message + ')');
+        return err;
+    }
+};
+
+internals.jsonParser = function (manifestPath) {
+    try {
+        return JSON.parse(Fs.readFileSync(manifestPath));
+    }
+    catch (err) {
+        console.log('Failed loading configuration file: ' + args.c + ' (' + err.message + ')');
+        return err;
+    }
+}
 
 internals.getManifest = function (args) {
 
     var manifest = null;
     var manifestPath = !Hoek.isAbsolutePath(args.c) ? Path.join(process.cwd(), args.c) : args.c;
+    var manifestExt = Path.extname(manifestPath);
 
-    try {
-        manifest = JSON.parse(Fs.readFileSync(manifestPath));
-    }
-    catch (err) {
-        console.log('Failed loading configuration file: ' + args.c + ' (' + err.message + ')');
-        return err;
+    switch (manifestExt) {
+        case '.js':
+            manifest = internals.jsParser(manifestPath, args);
+            break;
+        case '.json':
+            manifest = internals.jsonParser(manifestPath, args);
+            break;
     }
 
     internals.parseEnv(manifest);


### PR DESCRIPTION
This is an extra feature to pass the manifest as a .js like:
rejoice -c manifest.js

The manifest.js need to export an object with the same specifications as the json manifest an example of how the manifest.js looks like:

``` javascript
module.exports = {
    connections: [
        {
            port: 8080,
            labels: [
                'api',
                'http'
            ]
        }
    },
    plugins: {
        good: {
            opsInterval: 5000,
            requestHeaders: true,
            reporters: [{
                reporter: 'good-console',
                events: { response: '*', ops: '*', log: '*', error: '*' }
            },
        },
        lout: {}
    }
};
```

Please let me know if there anything i'm missing thanks.
