### PR TITLE
allow requiring multiple modules before application is loaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,13 @@ If you need a module required before your application is loaded you can use the 
 rejoice -c app.json -r `module`
 ```
 
-When using `-r` with the `-p` flag.  The `-p` flag takes on an additonal meaning.  In this case the `-p` specifies the path where the module specified in `-r` will be found.
+Multiple modules can be required by using the `-r` flag as many times as needed. This example requires two modules from an implied source of `node_modules`.
+
+```
+rejoice -c app.json -r babel/register -r dotenv/config
+```
+
+When using `-r` with the `-p` flag, the `-p` flag takes on an additional meaning.  In this case, the `-p` specifies the path where the module specified in `-r` will be found.
 
 ```javascript
 rejoice -c app.json -r `module` -p /base/path/to/required/module

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,7 +22,8 @@ internals.definition = {
     },
     r: {
         alias: 'require',
-        description: 'A module to be required before the application is loaded'
+        description: 'A module to be required before the application is loaded',
+        multiple: true
     },
     h: {
         alias: 'help',
@@ -47,24 +48,27 @@ internals.loadExtras = function (args) {
         nodeModulesPath = Path.join(Fs.realpathSync(args.p), 'node_modules');
     }
 
-    if (!Hoek.isAbsolutePath(extras)) {
-        if (extras[0] === '.') {
-            extrasPath = Path.join(process.cwd(), extras);
+    for (var i = 0, il = extras.length; i < il; i++) {
+        var extra = extras[i];
+        if (!Hoek.isAbsolutePath(extra)) {
+            if (extra[0] === '.') {
+                extrasPath = Path.join(process.cwd(), extra);
+            }
+            else {
+                extrasPath = Path.join(nodeModulesPath, extra);
+            }
         }
         else {
-            extrasPath = Path.join(nodeModulesPath, extras);
+            extrasPath = extra;
         }
-    }
-    else {
-        extrasPath = extras;
-    }
 
-    try {
-        require(extrasPath);
-    }
-    catch (err) {
-        console.error('Unable to require extra file: %s (%s)', extras, err.message);
-        return err;
+        try {
+            require(extrasPath);
+        }
+        catch (err) {
+            console.error('Unable to require extra file: %s (%s)', extra, err.message);
+            return err;
+        }
     }
 };
 


### PR DESCRIPTION
I needed to require two modules for a project and expected rejoice to work like node with regards to the `-r` flag.

```
$ node -r ./c1.js -r ./c2.js -e "console.log(3)"
1
2
3
```

Before this addition, Bossy produced an error when parsing the args. Now, you can require as many modules as you like.

```
$ rejoice -r babel/register -r dotenv/config -c config.json
```
