### PR TITLE
Don't load glue until just before it's needed

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@
 var Fs = require('fs');
 var Path = require('path');
 var Bossy = require('bossy');
-var Glue = require('glue');
+var Glue;
 var Hoek = require('hoek');
 
 
@@ -162,6 +162,8 @@ exports.start = function (options) {
     }
 
     internals.loadPacks(args, manifest, function (err, packOptions) {
+
+        Glue = require('glue');
 
         if (err) {
             console.error(err);


### PR DESCRIPTION
The newrelic module requires that it is loaded before hapi in order to properly instrument it. When using rejoice, glue is required, which requires hapi, before extra modules (using `-r`) are loaded. 

Moving the `require` call for glue into the function it is used solves the issue. 
